### PR TITLE
API Call Error Handling

### DIFF
--- a/Hubbub/SlotsViewController.swift
+++ b/Hubbub/SlotsViewController.swift
@@ -9,6 +9,7 @@
 import Alamofire
 import Firebase
 import MaterialComponents
+import MaterialComponents.MaterialSnackbar
 import SnapKit
 import UIKit
 
@@ -204,13 +205,18 @@ class SlotsViewController: UIViewController, UITableViewDataSource, UITableViewD
             let headers: HTTPHeaders = [
                 "Authorization": "Bearer \(token!)",
             ]
-            _ = Alamofire.request(
-                url,
-                method: .post,
-                parameters: params,
-                encoding: JSONEncoding.default,
-                headers: headers
-            )
+            Alamofire.request(url, method: .post, parameters: params, encoding: JSONEncoding.default, headers: headers)
+                .validate(statusCode: 200..<300)
+                .responseData { [weak self] (response) in
+                    guard case let .failure(err) = response.result else { return }
+                    print("API Error: \(err)")
+                    
+                    let message = MDCSnackbarMessage()
+                    message.text = (value) ? "Failed to join event" : "Failed to leave event"
+                    MDCSnackbarManager.show(message)
+                    
+                    self?.reloadCellFor(slotId: slotId)
+                }
         }
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -17,6 +17,7 @@ target 'Hubbub' do
   pod 'MaterialComponents/Buttons'
   pod 'MaterialComponents/Palettes'
   pod 'MaterialComponents/ShadowLayer'
+  pod 'MaterialComponents/Snackbar'
   pod 'p2.OAuth2', '~> 3.0'
   pod 'SnapKit', '~> 3.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,6 +48,7 @@ PODS:
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.1)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.1)
   - GTMSessionFetcher/Core (1.1.9)
+  - MaterialComponents/AnimationTiming (23.0.1)
   - MaterialComponents/AppBar (23.0.1):
     - MaterialComponents/FlexibleHeader
     - MaterialComponents/HeaderStackView
@@ -76,14 +77,27 @@ PODS:
     - MaterialComponents/private/RTL
     - MaterialComponents/Typography
     - MDFTextAccessibility
+  - MaterialComponents/OverlayWindow (23.0.1):
+    - MaterialComponents/private/Application
   - MaterialComponents/Palettes (23.0.1)
   - MaterialComponents/private/Application (23.0.1)
   - MaterialComponents/private/Icons/Base (23.0.1)
   - MaterialComponents/private/Icons/ic_arrow_back (23.0.1):
     - MaterialComponents/private/Icons/Base
+  - MaterialComponents/private/KeyboardWatcher (23.0.1):
+    - MaterialComponents/private/Application
+  - MaterialComponents/private/Overlay (23.0.1)
   - MaterialComponents/private/RTL (23.0.1)
   - MaterialComponents/ShadowElevations (23.0.1)
   - MaterialComponents/ShadowLayer (23.0.1)
+  - MaterialComponents/Snackbar (23.0.1):
+    - MaterialComponents/AnimationTiming
+    - MaterialComponents/Buttons
+    - MaterialComponents/OverlayWindow
+    - MaterialComponents/private/Application
+    - MaterialComponents/private/KeyboardWatcher
+    - MaterialComponents/private/Overlay
+    - MaterialComponents/Typography
   - MaterialComponents/Typography (23.0.1):
     - MaterialComponents/private/Application
   - MDFTextAccessibility (1.2.0)
@@ -105,6 +119,7 @@ DEPENDENCIES:
   - MaterialComponents/Buttons
   - MaterialComponents/Palettes
   - MaterialComponents/ShadowLayer
+  - MaterialComponents/Snackbar
   - p2.OAuth2 (~> 3.0)
   - SnapKit (~> 3.0)
 
@@ -129,6 +144,6 @@ SPEC CHECKSUMS:
   Protobuf: 2ccbaf193f6c65adc67745453ca0c13234c32796
   SnapKit: 1ca44df72cfa543218d177cb8aab029d10d86ea7
 
-PODFILE CHECKSUM: c0a3cd94e6e84197892b08586d74d4238c5cf53f
+PODFILE CHECKSUM: 713f984222823d0ec779dd5914efa5d8909f8186
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
Show error toasts and restore the UI when `joinSlot` or `leaveSlot` fail.